### PR TITLE
Build with poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,5 +49,5 @@ python = "~2.7 || ^3.5"
 alabaster = "<0.8"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Avoids requiring all of poetry just to build a wheel.